### PR TITLE
fix typo in reference WebSocket documentation

### DIFF
--- a/src/docs/asciidoc/web/websocket.adoc
+++ b/src/docs/asciidoc/web/websocket.adoc
@@ -663,7 +663,7 @@ The following example shows how to do so in Java configuration:
 ----
 	@Configuration
 	@EnableWebSocket
-	public class WebSocketConfig implements WebSocketConfigurer {
+	public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 		@Override
 		public void registerStompEndpoints(StompEndpointRegistry registry) {


### PR DESCRIPTION
changed interface type from WebSocketConfigurer to WebSocketMessageBrokerConfigurer.

`WebSocketConfigurer` have not  ` registerStompEndpoints(StompEndpointRegistry registry)`

```java
public interface WebSocketConfigurer {
    void registerWebSocketHandlers(WebSocketHandlerRegistry var1);
}
```

`WebSocketMessageBrokerConfigurer` have ` registerStompEndpoints(StompEndpointRegistry registry)`

```java
public interface WebSocketMessageBrokerConfigurer {
    default void registerStompEndpoints(StompEndpointRegistry registry) {
    }
    // ....
```